### PR TITLE
bump windows cookbook depenency, min chef version

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,6 +31,9 @@ platforms:
       gui: false
     provisioner:
       product_version: 13
+    transport:
+      name: winrm
+      username: administrator
 
 suites:
   - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache-2.0'
 description 'Application cookbook which installs and configures Consul.'
 long_description 'Application cookbook which installs and configures Consul.'
-version '3.1.4'
+version '3.1.5'
 
 recipe 'consul::default', 'Installs and configures the Consul service.'
 recipe 'consul::client_gem', 'Installs the Consul Ruby client as a gem.'
@@ -23,9 +23,9 @@ depends 'golang'
 depends 'poise', '~> 2.2'
 depends 'poise-archive', '~> 1.3'
 depends 'poise-service', '~> 1.4'
-depends 'windows', '~> 3.1'
+depends 'windows', '~> 6.0'
 
 source_url 'https://github.com/johnbellone/consul-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/johnbellone/consul-cookbook/issues' if respond_to?(:issues_url)
 
-chef_version '>= 12.1' if respond_to?(:chef_version)
+chef_version '>= 13' if respond_to?(:chef_version)


### PR DESCRIPTION
Windows cookbook needs bumped for Chef 14 compatibility for some other cookbooks. The locked dependency is causing issues elsewhere.